### PR TITLE
Fix decimal and checksum

### DIFF
--- a/dht11.cpp
+++ b/dht11.cpp
@@ -76,10 +76,10 @@ int dht11::read(int pin)
 
 	// WRITE TO RIGHT VARS
         // as bits[1] and bits[3] are allways zero they are omitted in formulas.
-	humidity    = bits[0]; 
-	temperature = bits[2]; 
+	humidity    = bits[0] + (bits[1] * 0.01); 
+	temperature = bits[2] + (bits[3] * 0.01); 
 
-	uint8_t sum = bits[0] + bits[2];  
+	uint8_t sum = (bits[0] + bits[1] + bits[2] + bits[3]) & 0xFF;  
 
 	if (bits[4] != sum) return DHTLIB_ERROR_CHECKSUM;
 	return DHTLIB_OK;

--- a/dht11.h
+++ b/dht11.h
@@ -31,9 +31,9 @@
 class dht11
 {
 public:
-    int read(int pin);
-	int humidity;
-	int temperature;
+  int read(int pin);
+  float humidity;
+  float temperature;
 };
 #endif
 //


### PR DESCRIPTION
My sensor is reporting decimal temperature values.
Because of that, the checksum wasn't working.
